### PR TITLE
Fix 'delete a todo' test to ensure data is populated before the delete

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -100,7 +100,7 @@ describe("server", function() {
             });
         });
         it("removes the item from the list of todos", function(done) {
-            request.put({
+            request.post({
                 url: todoListUrl,
                 json: {
                     title: "This is a TODO item",


### PR DESCRIPTION
1. By sending a 'put' http request, no todo would be created (creation
   should be done through 'post' http requests).
2. The delete request would then run and fail, but since this was not
   being tested this would not cause the test to fail.
3. Because no todo was created, the get request returns an empty list.
   Therefore this test is not actually testing the 'delete' behaviour.
